### PR TITLE
feat: revert to commitlint without gitmoji

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,1 +1,2 @@
-module.exports = { extends: ['gitmoji'] };
+// module.exports = { extends: ['gitmoji'] };
+module.exports = { extends: ['@commitlint/config-conventional'] };


### PR DESCRIPTION
still trying to figure out what why semantic release is not parsing well the commit msg 

related to https://jira.lyft.net/browse/MGW-451
