### PR TITLE
major: add new commit type for breaking change

### DIFF
--- a/.husky/prepare-commit-msg
+++ b/.husky/prepare-commit-msg
@@ -1,30 +1,31 @@
 #!/usr/bin/env node
 
-// hook that validates that a 'BREAKING CHANGE' commit message contains an exclamation mark (!) in
-// its subject (just after the commit type(scope))
+// hook that validates that a major change commit contains the mention 'BREAKING CHANGE'
 
 const fs = require('fs');
 
 const message = fs.readFileSync(process.argv[2], 'utf8').trim();
 
-if (!message.includes('BREAKING CHANGE') || message.includes('chore(release)')) {
+if (message.includes('chore(release)')) {
   process.exit(0);
 }
 
 const commitMsgSplitted = message.split('\n');
 const commitSubject = commitMsgSplitted[0];
 
-// use the following when MGW-540 is done
-// const commitEmojiAndTypeRegex = /^:[A-Za-z]*: [A-Za-z()]*!:/g; 
-// const commitEmojiAndType = commitSubject.match(commitEmojiAndTypeRegex);
+const majorCommitTypeRegex = /^major[(a-zA-Z.)]*:/g;
+const majorCommitType = commitSubject.match(majorCommitTypeRegex);
 
-const commitTypeRegex = /^[A-Za-z()]*!:/g; 
-const commitType = commitSubject.match(commitTypeRegex);
+if (!majorCommitType || majorCommitType.length === 0) {
+  process.exit(0);
+}
 
-// if (!commitEmojiAndType || commitEmojiAndType.length === 0) { use the following when MGW-540 is done
-if (!commitType || commitType.length === 0) {
+if (
+  !message.includes('BREAKING CHANGE:') &&
+  !message.includes('BREAKING CHANGES:')
+) {
   console.log(
-    "❌ Wrong commit format for a BREAKING CHANGE. Please add an exclamation mark '!' just after your commit type(scope).\nFor example: :sparkles: feat(ui)!: new component"
+    "❌ Wrong commit format for a major change. Please mention 'BREAKING CHANGE:' at the beginning of the commit footer and explain the breaking change."
   );
 
   process.exit(1);

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,15 +70,15 @@ We follow the [Conventional Commit convention](https://www.conventionalcommits.o
 - `build`: changes to the build process.
 - `chore`: any chore project changes
 
-If your changes introduce any breaking changes, make sure to specify an exclamation point (!) after your commit type(scope) and  'BREAKING CHANGE' in the footer of your commit message. Refer to [Conventional Commit convention](https://www.conventionalcommits.org/en/v1.0.0-beta.4/) for more details.
+If your changes introduce any breaking changes, you have to specify 'major' as commit type.
 
 Some guidelines to follow when writting commit messages:
 - Commit message needs to start with a present tense verb. For example, write: 'add new component' instead of 'added new component'
 - Provide a message body that explains the changes you have made and why they are needed
 - when your change is a BREAKING CHANGE:
-  - put an '!' mark right after the subject/scope. For example:
-    - feat!: add a new feature 
-    - fix(PBSCDropdown)!: remvove a property  
+  - put 'major' as commit type. For example:
+    - major: add new component
+    - major(PBSCDropdown)!: remvove a property  
   - provide a message in the footer that begins with 'BREAKING CHANGE:'
 
 Our pre-commit hooks verify that your commit message matches this format when committing.

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,1 +1,23 @@
-module.exports = { extends: ['@commitlint/config-conventional'] };
+module.exports = {
+  extends: ['@commitlint/config-conventional'],
+  rules: {
+    'type-enum': [
+      2,
+      'always',
+      [
+        'feat',
+        'fix',
+        'docs',
+        'style',
+        'major',
+        'ci',
+        'build',
+        'chore',
+        'perf',
+        'test',
+        'revert',
+        'refactor',
+      ],
+    ],
+  },
+};

--- a/package.json
+++ b/package.json
@@ -154,7 +154,57 @@
   },
   "config": {
     "commitizen": {
-      "path": "./node_modules/cz-conventional-changelog"
+      "path": "./node_modules/cz-conventional-changelog",
+      "types": {
+        "feat": {
+          "description": "A new feature",
+          "title": "Feature"
+        },
+        "fix": {
+          "description": "A bug fix",
+          "title": "Bug Fix"
+        },
+        "docs": {
+          "description": "Documentation only changes",
+          "title": "Documentation"
+        },
+        "style": {
+          "description": "Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)",
+          "title": "Style"
+        },
+        "refactor": {
+          "description": "A code change that neither fixes a bug nor adds a feature",
+          "title": "Refactor"
+        },
+        "perf": {
+          "description": "A code change that improves performance",
+          "title": "Performance"
+        },
+        "test": {
+          "description": "Adding missing tests or correcting existing tests",
+          "title": "Tests"
+        },
+        "major": {
+          "description": "A breaking change change that should introduce major version upgrade",
+          "title": "Major change"
+        },
+        "build": {
+          "description": "Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)",
+          "title": "Build"
+        },
+        "ci": {
+          "description": "Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)",
+          "title": "CI"
+        },
+        "chore": {
+          "description": "Other changes that don't modify src or test files",
+          "title": "Chore"
+        },
+        "revert": {
+          "description": "Reverts a previous commit",
+          "title": "Revert"
+        }
+      }
     }
   }
 }

--- a/release.config.js
+++ b/release.config.js
@@ -42,6 +42,10 @@ module.exports = {
             type: 'revert',
             release: 'patch',
           },
+          {
+            type: 'major',
+            release: 'major',
+          },
         ],
         parserOpts: {
           noteKeywords: ['BREAKING CHANGE', 'BREAKING CHANGES'],


### PR DESCRIPTION
### To which ticket/issue is this PR linked to?

https://jira.lyft.net/browse/MGW-451

### What does this PR add, change or fix?

- add major as new commit type for breaking change commits so that major version gets updated



## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [x] CI/CD or build process changes
- [ ] Other