### PR TITLE
ci(release.config.js): reorder semantic release plugins

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -105,8 +105,8 @@ module.exports = {
         },
       },
     ],
+    '@semantic-release/npm',
     '@semantic-release/git',
     '@semantic-release/github',
-    '@semantic-release/npm',
   ],
 };


### PR DESCRIPTION

### To which ticket/issue is this PR linked to?

MGW-451

### What does this PR add, change or fix?

-  reorder semantic release plugins to put npm plugin before git plugins
   - Trying to see why semantic release bot does not start (package.json version is not updating for couple of releases now)


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] CI/CD or build process changes
- [ ] Other